### PR TITLE
Fail fast!

### DIFF
--- a/converter-logansquare/src/main/java/com/github/aurae/retrofit2/LoganSquareConverterFactory.java
+++ b/converter-logansquare/src/main/java/com/github/aurae/retrofit2/LoganSquareConverterFactory.java
@@ -28,11 +28,23 @@ public final class LoganSquareConverterFactory extends Converter.Factory {
 
     @Override
     public Converter<ResponseBody, ?> responseBodyConverter(Type type, Annotation[] annotations, Retrofit retrofit) {
+        if (!(type instanceof Class)) {
+            return null;
+        }
+        if (!LoganSquare.supports((Class) type)) {
+            return null;
+        }
         return new LoganSquareResponseBodyConverter(type);
     }
 
     @Override
     public Converter<?, RequestBody> requestBodyConverter(Type type, Annotation[] parameterAnnotations, Annotation[] methodAnnotations, Retrofit retrofit) {
+        if (!(type instanceof Class)) {
+            return null;
+        }
+        if (!LoganSquare.supports((Class) type)) {
+            return null;
+        }
         return new LoganSquareRequestBodyConverter(type);
     }
 }

--- a/converter-logansquare/src/main/java/com/github/aurae/retrofit2/LoganSquareConverterFactory.java
+++ b/converter-logansquare/src/main/java/com/github/aurae/retrofit2/LoganSquareConverterFactory.java
@@ -28,7 +28,10 @@ public final class LoganSquareConverterFactory extends Converter.Factory {
 
     @Override
     public Converter<ResponseBody, ?> responseBodyConverter(Type type, Annotation[] annotations, Retrofit retrofit) {
-        if (!LoganSquare.supports((Class) type)) {
+        if (type instanceof Class && !LoganSquare.supports((Class) type)) {
+            return null;
+        }
+        if (type instanceof ParameterizedType && !LoganSquare.supports((ParameterizedType) type)) {
             return null;
         }
         return new LoganSquareResponseBodyConverter(type);
@@ -36,7 +39,10 @@ public final class LoganSquareConverterFactory extends Converter.Factory {
 
     @Override
     public Converter<?, RequestBody> requestBodyConverter(Type type, Annotation[] parameterAnnotations, Annotation[] methodAnnotations, Retrofit retrofit) {
-        if (!LoganSquare.supports((Class) type)) {
+        if (type instanceof Class && !LoganSquare.supports((Class) type)) {
+            return null;
+        }
+        if (type instanceof ParameterizedType && !LoganSquare.supports((ParameterizedType) type)) {
             return null;
         }
         return new LoganSquareRequestBodyConverter(type);

--- a/converter-logansquare/src/main/java/com/github/aurae/retrofit2/LoganSquareConverterFactory.java
+++ b/converter-logansquare/src/main/java/com/github/aurae/retrofit2/LoganSquareConverterFactory.java
@@ -28,9 +28,6 @@ public final class LoganSquareConverterFactory extends Converter.Factory {
 
     @Override
     public Converter<ResponseBody, ?> responseBodyConverter(Type type, Annotation[] annotations, Retrofit retrofit) {
-        if (!(type instanceof Class)) {
-            return null;
-        }
         if (!LoganSquare.supports((Class) type)) {
             return null;
         }
@@ -39,9 +36,6 @@ public final class LoganSquareConverterFactory extends Converter.Factory {
 
     @Override
     public Converter<?, RequestBody> requestBodyConverter(Type type, Annotation[] parameterAnnotations, Annotation[] methodAnnotations, Retrofit retrofit) {
-        if (!(type instanceof Class)) {
-            return null;
-        }
         if (!LoganSquare.supports((Class) type)) {
             return null;
         }


### PR DESCRIPTION
Hey there. So if you take a look at other converters, such as the SimpleXml converter, they are returning null if they can not handle the Retrofit conversion. This way, if there is another converter that can handle it, they have an opportunity, instead of LoganSquare saying it can handle it, then failing. That is what would happen presently if you were to have a model meant for SimpleXml and LoganSquare converter was registered first 
https://github.com/square/retrofit/blob/master/retrofit-converters/simplexml/src/main/java/retrofit2/converter/simplexml/SimpleXmlConverterFactory.java
^ You can see it in action there. I think this may be something that people would want to opt in/out of, but just wanted to get your initial thoughts. LoganSquare has an advantage over other libraries in this sense, due to the fact that you have to explicitly declare your models with `@JsonObject` which allows this quick failure. 