### PR TITLE
Fail fast!

### DIFF
--- a/converter-logansquare/src/main/java/com/github/aurae/retrofit2/LoganSquareConverterFactory.java
+++ b/converter-logansquare/src/main/java/com/github/aurae/retrofit2/LoganSquareConverterFactory.java
@@ -28,11 +28,23 @@ public final class LoganSquareConverterFactory extends Converter.Factory {
 
     @Override
     public Converter<ResponseBody, ?> responseBodyConverter(Type type, Annotation[] annotations, Retrofit retrofit) {
+        if (!(type instanceof Class)) {
+            return null;
+        }
+        if (!LoganSquare.supports((Class) type)) {
+            return null;
+        }
         return new LoganSquareResponseBodyConverter(type);
     }
 
     @Override
     public Converter<?, RequestBody> requestBodyConverter(Type type, Annotation[] parameterAnnotations, Annotation[] methodAnnotations, Retrofit retrofit) {
+        if (!(type instanceof Class)) {
+            return null;
+        }
+        if (!LoganSquare.supports((Class) type)) {
+            return null;
+        }
         return new LoganSquareRequestBodyConverter(type);
     }
 }

--- a/converter-logansquare/src/main/java/com/github/aurae/retrofit2/LoganSquareConverterFactory.java
+++ b/converter-logansquare/src/main/java/com/github/aurae/retrofit2/LoganSquareConverterFactory.java
@@ -28,7 +28,10 @@ public final class LoganSquareConverterFactory extends Converter.Factory {
 
     @Override
     public Converter<ResponseBody, ?> responseBodyConverter(Type type, Annotation[] annotations, Retrofit retrofit) {
-        if (!LoganSquare.supports((Class) type)) {
+        if (type instanceof Class && !LoganSquare.supports((Class) type)) {
+            return null;
+        }
+        if (type instanceof ParameterizedType && !LoganSquare.supports((ParameterizedType) type)) {
             return null;
         }
         return new LoganSquareResponseBodyConverter(type);
@@ -36,7 +39,10 @@ public final class LoganSquareConverterFactory extends Converter.Factory {
 
     @Override
     public Converter<?, RequestBody> requestBodyConverter(Type type, Annotation[] parameterAnnotations, Annotation[] methodAnnotations, Retrofit retrofit) {
-        if (!LoganSquare.supports((Class) type)) {
+        if (type instanceof Class && !LoganSquare.supports((Class) type)) {
+            return null;
+        }
+        if (type instanceof ParameterizedType && !LoganSquare.supports((ParameterizedType) type)) {
             return null;
         }
         return new LoganSquareRequestBodyConverter(type);

--- a/converter-logansquare/src/main/java/com/github/aurae/retrofit2/LoganSquareConverterFactory.java
+++ b/converter-logansquare/src/main/java/com/github/aurae/retrofit2/LoganSquareConverterFactory.java
@@ -1,5 +1,7 @@
 package com.github.aurae.retrofit2;
 
+import com.bluelinelabs.logansquare.LoganSquare;
+import com.bluelinelabs.logansquare.ParameterizedType;
 import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
 import retrofit2.Converter;
@@ -7,6 +9,8 @@ import retrofit2.Retrofit;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
 
 
 /**
@@ -17,6 +21,7 @@ import java.lang.reflect.Type;
 public final class LoganSquareConverterFactory extends Converter.Factory {
     /**
      * Create an instance. Encoding to JSON and decoding from JSON will use UTF-8.
+     *
      * @return A {@linkplain Converter.Factory} configured to serve LoganSquare converters
      */
     public static LoganSquareConverterFactory create() {
@@ -26,25 +31,60 @@ public final class LoganSquareConverterFactory extends Converter.Factory {
     private LoganSquareConverterFactory() {
     }
 
+    private boolean isSupported(Type type) {
+        // Check ordinary Class
+        if (type instanceof Class && !LoganSquare.supports((Class) type)) {
+            return false;
+        }
+
+        // Check LoganSquare's ParameterizedType
+        if (type instanceof ParameterizedType && !LoganSquare.supports((ParameterizedType) type)) {
+            return false;
+        }
+
+        // Check target types of java.lang.reflect.ParameterizedType
+        if (type instanceof java.lang.reflect.ParameterizedType) {
+            java.lang.reflect.ParameterizedType pt = (java.lang.reflect.ParameterizedType) type;
+            Type[] typeArguments = pt.getActualTypeArguments();
+            Type firstType = typeArguments[0];
+
+            Type rawType = pt.getRawType();
+            if (rawType == Map.class) {
+                // LoganSquare only handles Map objects with String keys and supported types
+                Type secondType = typeArguments[1];
+                if (firstType != String.class || !isSupported(secondType)) {
+                    return false;
+                }
+
+            } else if (rawType == List.class) {
+                // LoganSquare only handles List objects of supported types
+                if (!isSupported(firstType)) {
+                    return false;
+                }
+
+            } else {
+                // TODO Generics
+            }
+        }
+
+        return true;
+    }
+
     @Override
     public Converter<ResponseBody, ?> responseBodyConverter(Type type, Annotation[] annotations, Retrofit retrofit) {
-        if (type instanceof Class && !LoganSquare.supports((Class) type)) {
+        if (isSupported(type)) {
+            return new LoganSquareResponseBodyConverter(type);
+        } else {
             return null;
         }
-        if (type instanceof ParameterizedType && !LoganSquare.supports((ParameterizedType) type)) {
-            return null;
-        }
-        return new LoganSquareResponseBodyConverter(type);
     }
 
     @Override
     public Converter<?, RequestBody> requestBodyConverter(Type type, Annotation[] parameterAnnotations, Annotation[] methodAnnotations, Retrofit retrofit) {
-        if (type instanceof Class && !LoganSquare.supports((Class) type)) {
+        if (isSupported(type)) {
+            return new LoganSquareRequestBodyConverter(type);
+        } else {
             return null;
         }
-        if (type instanceof ParameterizedType && !LoganSquare.supports((ParameterizedType) type)) {
-            return null;
-        }
-        return new LoganSquareRequestBodyConverter(type);
     }
 }

--- a/converter-logansquare/src/main/java/com/github/aurae/retrofit2/LoganSquareConverterFactory.java
+++ b/converter-logansquare/src/main/java/com/github/aurae/retrofit2/LoganSquareConverterFactory.java
@@ -28,9 +28,6 @@ public final class LoganSquareConverterFactory extends Converter.Factory {
 
     @Override
     public Converter<ResponseBody, ?> responseBodyConverter(Type type, Annotation[] annotations, Retrofit retrofit) {
-        if (!(type instanceof Class)) {
-            return null;
-        }
         if (!LoganSquare.supports((Class) type)) {
             return null;
         }
@@ -39,9 +36,6 @@ public final class LoganSquareConverterFactory extends Converter.Factory {
 
     @Override
     public Converter<?, RequestBody> requestBodyConverter(Type type, Annotation[] parameterAnnotations, Annotation[] methodAnnotations, Retrofit retrofit) {
-        if (!(type instanceof Class)) {
-            return null;
-        }
         if (!LoganSquare.supports((Class) type)) {
             return null;
         }

--- a/converter-logansquare/src/main/java/com/github/aurae/retrofit2/LoganSquareRequestBodyConverter.java
+++ b/converter-logansquare/src/main/java/com/github/aurae/retrofit2/LoganSquareRequestBodyConverter.java
@@ -6,10 +6,7 @@ import okhttp3.RequestBody;
 import retrofit2.Converter;
 
 import java.io.IOException;
-import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.util.List;
-import java.util.Map;
 
 final class LoganSquareRequestBodyConverter implements Converter<Object, RequestBody> {
 
@@ -23,15 +20,6 @@ final class LoganSquareRequestBodyConverter implements Converter<Object, Request
 
     @Override
     public RequestBody convert(Object value) throws IOException {
-        if (type instanceof ParameterizedType) {
-            // Check for generics types
-            ParameterizedType parameterizedType = (ParameterizedType) type;
-            Type rawType = parameterizedType.getRawType();
-            if (rawType != List.class && rawType != Map.class) {
-                // TODO Generics
-            }
-        }
-
         // For general cases, use the central LoganSquare serialization method
         return RequestBody.create(MEDIA_TYPE, LoganSquare.serialize(value));
     }

--- a/converter-logansquare/src/main/java/com/github/aurae/retrofit2/LoganSquareResponseBodyConverter.java
+++ b/converter-logansquare/src/main/java/com/github/aurae/retrofit2/LoganSquareResponseBodyConverter.java
@@ -35,19 +35,11 @@ final class LoganSquareResponseBodyConverter implements Converter<ResponseBody, 
                 // Check for Map arguments
                 Type rawType = parameterizedType.getRawType();
                 if (rawType == Map.class) {
-                    Type secondType = typeArguments[1];
-
-                    // Perform validity checks on the type arguments, since LoganSquare works only on String keys
-                    if (firstType == String.class && secondType instanceof Class) {
-                        // Map conversion
-                        return LoganSquare.parseMap(is, (Class<?>) secondType);
-                    }
+                    return LoganSquare.parseMap(is, (Class<?>) typeArguments[1]);
 
                 } else if (rawType == List.class) {
-                    if (firstType instanceof Class) {
-                        // List conversion
-                        return LoganSquare.parseList(is, (Class<?>) firstType);
-                    }
+                    return LoganSquare.parseList(is, (Class<?>) firstType);
+
                 } else {
                     // TODO Generics
                 }

--- a/converter-logansquare/src/test/java/com/github/aurae/retrofit2/LoganSquareConverterTest.java
+++ b/converter-logansquare/src/test/java/com/github/aurae/retrofit2/LoganSquareConverterTest.java
@@ -2,6 +2,7 @@ package com.github.aurae.retrofit2;
 
 import com.github.aurae.retrofit2.model.BasicModel;
 import com.github.aurae.retrofit2.model.CustomEnum;
+import com.github.aurae.retrofit2.model.ForeignModel;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -40,6 +41,24 @@ public class LoganSquareConverterTest {
 
         @POST("/")
         Call<BasicModel[]> callArray(@Body BasicModel[] body);
+
+        @POST("/")
+        Call<BasicModel> callObjectRequestNotSupported(@Body ForeignModel body);
+
+        @POST("/")
+        Call<ForeignModel> callObjectResponseNotSupported(@Body BasicModel body);
+
+        @POST("/")
+        Call<BasicModel> callListRequestNotSupported(@Body List<ForeignModel> body);
+
+        @POST("/")
+        Call<List<ForeignModel>> callListResponseNotSupported(@Body BasicModel body);
+
+        @POST("/")
+        Call<BasicModel> callMapRequestNotSupported(@Body Map<String, ForeignModel> body);
+
+        @POST("/")
+        Call<Map<String, ForeignModel>> callMapResponseNotSupported(@Body BasicModel body);
     }
 
     @Rule
@@ -54,6 +73,80 @@ public class LoganSquareConverterTest {
                 .addConverterFactory(LoganSquareConverterFactory.create())
                 .build()
                 .create(Service.class);
+    }
+
+    @Test
+    public void testDoesntSupportObjectRequest() throws IOException, InterruptedException {
+        ForeignModel requestBody = new ForeignModel();
+
+        try {
+            // Call the API and execute it
+            service.callObjectRequestNotSupported(requestBody).execute();
+            Assertions.failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    @Test
+    public void testDoesntSupportObjectResponse() throws IOException, InterruptedException {
+        BasicModel requestBody = new BasicModel();
+
+        try {
+            // Call the API and execute it
+            service.callObjectResponseNotSupported(requestBody).execute();
+            Assertions.failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    @Test
+    public void testDoesntSupportListRequest() throws IOException, InterruptedException {
+        List<ForeignModel> requestBody = new ArrayList<>();
+        requestBody.add(new ForeignModel());
+
+        try {
+            // Call the API and execute it
+            service.callListRequestNotSupported(requestBody).execute();
+            Assertions.failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    @Test
+    public void testDoesntSupportListResponse() throws IOException, InterruptedException {
+        BasicModel requestBody = new BasicModel();
+
+        try {
+            // Call the API and execute it
+            service.callListResponseNotSupported(requestBody).execute();
+            Assertions.failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    @Test
+    public void testDoesntSupportMapRequest() throws IOException, InterruptedException {
+        Map<String, ForeignModel> requestBody = new HashMap<>();
+        requestBody.put("obj", new ForeignModel());
+
+        try {
+            // Call the API and execute it
+            service.callMapRequestNotSupported(requestBody).execute();
+            Assertions.failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    @Test
+    public void testDoesntSupportMapResponse() throws IOException, InterruptedException {
+        BasicModel requestBody = new BasicModel();
+
+        try {
+            // Call the API and execute it
+            service.callMapResponseNotSupported(requestBody).execute();
+            Assertions.failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
+        } catch (IllegalArgumentException ignored) {
+        }
     }
 
     @Test

--- a/converter-logansquare/src/test/java/com/github/aurae/retrofit2/model/ForeignModel.java
+++ b/converter-logansquare/src/test/java/com/github/aurae/retrofit2/model/ForeignModel.java
@@ -1,0 +1,5 @@
+package com.github.aurae.retrofit2.model;
+
+// Not annotated with @JsonObject, so that LoganSquare doesn't support this
+public class ForeignModel {
+}


### PR DESCRIPTION
Refined @Jawnnypoo's implementation to lift the responsibility of compatibility checks from the Converter objects, and instead placing them inside the Factory that distributes them.

@Jawnnypoo: How do you feel about this approach? It covers all current use cases (that is, everything excluding generics) and is backed by unit tests. Speaking of which, you mentioned that the tests were failing on your end, which is something I was able to reproduce until I performed a Gradle `clean build` which properly initialized the build environment and generated code from apt. After that, the tests worked. Maybe this will help you, too?